### PR TITLE
@types/request has same major version as request

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@types/express": "^4.0.35",
     "@types/node": "^7.0.18",
-    "@types/request": "0.0.43",
+    "@types/request": "2.0.7",
     "@types/sha1": "^1.1.0",
     "typescript": "^2.3.2"
   }


### PR DESCRIPTION
Previously it was 0.43 when request's major version was 2. This fixes compile errors in Typescript 2.6+.